### PR TITLE
fix: clusterwide overlay deploys namespace resource

### DIFF
--- a/config/overlays/clusterwide/kustomization.yaml
+++ b/config/overlays/clusterwide/kustomization.yaml
@@ -17,4 +17,5 @@ labels:
       app.kubernetes.io/managed-by: kustomize
 
 resources:
+  - namespace.yaml
   - ../../default

--- a/config/overlays/clusterwide/namespace.yaml
+++ b/config/overlays/clusterwide/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: default
+---


### PR DESCRIPTION
- clusterwide overlay should rollout a namespace manifest
- namespaced overlay by design needs a given namespace
