### PR TITLE
chore: set replicas to 2 as default

### DIFF
--- a/config/default/manager.yaml
+++ b/config/default/manager.yaml
@@ -13,7 +13,7 @@ spec:
     matchLabels:
       control-plane: controller-manager
       app.kubernetes.io/name: k8s-tls-rotator
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Updated the gateway-rotator deployment to run with 2 replicas instead of 1 to provide high availability and redundancy.