### PR TITLE
ci(release): pin conventional-changelog-conventionalcommits to 9.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           extra_plugins: |
             semantic-release-export-data
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@9.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Problem

Release [1.1.1](https://github.com/telekom/gateway-rotator/releases/tag/1.1.1) was published with an empty changelog body (header only, no commit sections), despite 5 commits since 1.1.0.

## Root cause

`conventional-changelog-conventionalcommits` is pulled in **unpinned** via `extra_plugins` (it's not a transitive dependency of `@semantic-release/release-notes-generator`, so it must be supplied explicitly). On 2026-06-26, upstream released a breaking `10.0.0`: Handlebars template strings were replaced with render functions (`@conventional-changelog/template@1.0.0`).

`@semantic-release/release-notes-generator` (latest, `14.1.1`) still depends on `conventional-changelog-writer@^8.0.0`, which only understands Handlebars **strings**. Fed a render **function** instead, it silently produces an empty template — no error, just a blank changelog.

The 2026-07-02 release run installed `latest` (10.2.0) and hit this. All prior releases resolved to 9.x and worked fine.

Verified locally: reproduced the exact empty-body bug with `conventional-changelog-conventionalcommits@10.2.0`, confirmed correct output restored with `@9.3.1` (last pre-breaking-change release), using the actual 5 commits from the 1.1.1 release.

Same root cause and fix as [telekom/gateway-issuer-service-go#23](https://github.com/telekom/gateway-issuer-service-go/pull/23), which uses an identical release pipeline.

## Fix

Pin `conventional-changelog-conventionalcommits` to `9.3.1` in `.github/workflows/release.yml`.

## Follow-up

Release 1.1.1's notes on GitHub have already been manually corrected to match what semantic-release should have generated.